### PR TITLE
Update transform and proto deps

### DIFF
--- a/exporters/metric/dynamicconfig/config.go
+++ b/exporters/metric/dynamicconfig/config.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"errors"
 
-	pb "github.com/vmingchen/opentelemetry-proto/gen/go/collector/dynamicconfig/v1"
+	pb "github.com/open-telemetry/opentelemetry-proto/gen/go/collector/dynamicconfig/v1"
 )
 
 // A configuration used in the SDK to dynamically change metric collection and tracing.

--- a/exporters/metric/dynamicconfig/config_test.go
+++ b/exporters/metric/dynamicconfig/config_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	pb "github.com/vmingchen/opentelemetry-proto/gen/go/collector/dynamicconfig/v1"
+	pb "github.com/open-telemetry/opentelemetry-proto/gen/go/collector/dynamicconfig/v1"
 
 	"go.opentelemetry.io/contrib/exporters/metric/dynamicconfig"
 )

--- a/exporters/metric/dynamicconfig/example/go.mod
+++ b/exporters/metric/dynamicconfig/example/go.mod
@@ -12,7 +12,7 @@ replace go.opentelemetry.io/otel/exporters/otlp => github.com/open-telemetry/ope
 
 require (
 	github.com/open-telemetry/opentelemetry-proto v0.3.0 // indirect
-	github.com/vmingchen/opentelemetry-proto v0.3.1-0.20200611154326-5406581153f7
+	github.com/open-telemetry/opentelemetry-proto v0.3.1-0.20200611154326-5406581153f7
 	go.opentelemetry.io/contrib v0.6.1
 	go.opentelemetry.io/contrib/exporters/metric/dynamicconfig v0.6.1
 	go.opentelemetry.io/otel v0.6.0

--- a/exporters/metric/dynamicconfig/example/go.sum
+++ b/exporters/metric/dynamicconfig/example/go.sum
@@ -938,8 +938,8 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasthttp v1.2.0/go.mod h1:4vX61m6KN+xDduDNwXrhIAVZaZaZiQ1luJk8LWSxF3s=
 github.com/valyala/quicktemplate v1.2.0/go.mod h1:EH+4AkTd43SvgIbQHYu59/cJyxDoOVRUAfrukLPuGJ4=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
-github.com/vmingchen/opentelemetry-proto v0.3.1-0.20200611154326-5406581153f7 h1:EF3bwMrVvRvCsohxf26MdQxR13QG33ZQvMdLd0vLnFY=
-github.com/vmingchen/opentelemetry-proto v0.3.1-0.20200611154326-5406581153f7/go.mod h1:L2ZI0c8uiqieH8UtekYdPKK1B4MKAdplt46DUjTilK4=
+github.com/open-telemetry/opentelemetry-proto v0.3.1-0.20200611154326-5406581153f7 h1:EF3bwMrVvRvCsohxf26MdQxR13QG33ZQvMdLd0vLnFY=
+github.com/open-telemetry/opentelemetry-proto v0.3.1-0.20200611154326-5406581153f7/go.mod h1:L2ZI0c8uiqieH8UtekYdPKK1B4MKAdplt46DUjTilK4=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=

--- a/exporters/metric/dynamicconfig/example/server/server.go
+++ b/exporters/metric/dynamicconfig/example/server/server.go
@@ -22,7 +22,7 @@ import (
 
 	"google.golang.org/grpc"
 
-	pb "github.com/vmingchen/opentelemetry-proto/gen/go/collector/dynamicconfig/v1"
+	pb "github.com/open-telemetry/opentelemetry-proto/gen/go/collector/dynamicconfig/v1"
 )
 
 const (

--- a/exporters/metric/dynamicconfig/go.mod
+++ b/exporters/metric/dynamicconfig/go.mod
@@ -6,13 +6,14 @@ replace go.opentelemetry.io/contrib => ../../..
 
 replace go.opentelemetry.io/otel => github.com/open-telemetry/opentelemetry-go v0.6.1-0.20200623190015-2966505271c3
 
+replace github.com/open-telemetry/opentelemetry-proto => ../../../../opentelemetry-proto
+
 require (
 	github.com/benbjohnson/clock v1.0.3
 	github.com/open-telemetry/opentelemetry-collector v0.3.0
 	github.com/open-telemetry/opentelemetry-proto v0.3.0
 	github.com/stretchr/testify v1.4.0
-	github.com/vmingchen/opentelemetry-proto v0.3.1-0.20200611154326-5406581153f7
 	go.opentelemetry.io/contrib v0.6.1
-	go.opentelemetry.io/otel v0.6.0
-	google.golang.org/grpc v1.29.1
+	go.opentelemetry.io/otel v0.7.0
+	google.golang.org/grpc v1.30.0
 )

--- a/exporters/metric/dynamicconfig/go.sum
+++ b/exporters/metric/dynamicconfig/go.sum
@@ -393,6 +393,7 @@ github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.2.2-0.20190730201129-28a6bbf47e48/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/gogo/protobuf v1.3.0 h1:G8O7TerXerS4F6sx9OV7/nRfJdnXgHZu/S/7F2SN+UE=
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/gddo v0.0.0-20180828051604-96d2a289f41e/go.mod h1:xEhNfoBDX1hzLm2Nf80qUvZ2sVwoMZ8d6IE2SrsQfh4=
@@ -710,8 +711,6 @@ github.com/open-telemetry/opentelemetry-collector v0.3.0 h1:/i106g9t6xNQ4hOAuczE
 github.com/open-telemetry/opentelemetry-collector v0.3.0/go.mod h1:c5EgyLBK6FoGCaJpOEQ0j+sHqmfuoRzOm29tdVA/wDg=
 github.com/open-telemetry/opentelemetry-go v0.6.1-0.20200623190015-2966505271c3 h1:ZORjd+BgbRDBN9x8F1e47veI/0KNXJczRiWVk/x+sec=
 github.com/open-telemetry/opentelemetry-go v0.6.1-0.20200623190015-2966505271c3/go.mod h1:MmQAfn48qCYlcM/csbDTXA2wgYlB3peeL/oCcDjR3Fo=
-github.com/open-telemetry/opentelemetry-proto v0.3.0 h1:+ASAtcayvoELyCF40+rdCMlBOhZIn5TPDez85zSYc30=
-github.com/open-telemetry/opentelemetry-proto v0.3.0/go.mod h1:PMR5GI0F7BSpio+rBGFxNm6SLzg3FypDTcFuQZnO+F8=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
@@ -917,8 +916,6 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasthttp v1.2.0/go.mod h1:4vX61m6KN+xDduDNwXrhIAVZaZaZiQ1luJk8LWSxF3s=
 github.com/valyala/quicktemplate v1.2.0/go.mod h1:EH+4AkTd43SvgIbQHYu59/cJyxDoOVRUAfrukLPuGJ4=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
-github.com/vmingchen/opentelemetry-proto v0.3.1-0.20200611154326-5406581153f7 h1:EF3bwMrVvRvCsohxf26MdQxR13QG33ZQvMdLd0vLnFY=
-github.com/vmingchen/opentelemetry-proto v0.3.1-0.20200611154326-5406581153f7/go.mod h1:L2ZI0c8uiqieH8UtekYdPKK1B4MKAdplt46DUjTilK4=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
@@ -1207,9 +1204,8 @@ google.golang.org/grpc v1.22.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
-google.golang.org/grpc v1.28.1/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
-google.golang.org/grpc v1.29.1 h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=
-google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
+google.golang.org/grpc v1.30.0 h1:M5a8xTlYTxwMn5ZFkwhRabsygDY5G8TYLyQDBxJNAxE=
+google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/exporters/metric/dynamicconfig/mock_config_service_test.go
+++ b/exporters/metric/dynamicconfig/mock_config_service_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 
 	"github.com/open-telemetry/opentelemetry-collector/translator/conventions"
-	pb "github.com/vmingchen/opentelemetry-proto/gen/go/collector/dynamicconfig/v1"
+	pb "github.com/open-telemetry/opentelemetry-proto/gen/go/collector/dynamicconfig/v1"
 
 	"google.golang.org/grpc"
 

--- a/exporters/metric/dynamicconfig/servicereader.go
+++ b/exporters/metric/dynamicconfig/servicereader.go
@@ -19,8 +19,8 @@ import (
 	"time"
 
 	"github.com/benbjohnson/clock"
+	pb "github.com/open-telemetry/opentelemetry-proto/gen/go/collector/dynamicconfig/v1"
 	resourcepb "github.com/open-telemetry/opentelemetry-proto/gen/go/resource/v1"
-	pb "github.com/vmingchen/opentelemetry-proto/gen/go/collector/dynamicconfig/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )

--- a/internal/transform/attribute_test.go
+++ b/internal/transform/attribute_test.go
@@ -26,7 +26,7 @@ import (
 func TestAttributes(t *testing.T) {
 	for _, test := range []struct {
 		attrs    []kv.KeyValue
-		expected []*commonpb.AttributeKeyValue
+		expected []*commonpb.KeyValue
 	}{
 		{nil, nil},
 		{
@@ -42,56 +42,86 @@ func TestAttributes(t *testing.T) {
 				kv.String("string to string", "string"),
 				kv.Bool("bool to bool", true),
 			},
-			[]*commonpb.AttributeKeyValue{
+			[]*commonpb.KeyValue{
 				{
-					Key:      "int to int",
-					Type:     commonpb.AttributeKeyValue_INT,
-					IntValue: 123,
+					Key: "int to int",
+					Value: &commonpb.AnyValue{
+						Value: &commonpb.AnyValue_IntValue{
+							IntValue: 123,
+						},
+					},
 				},
 				{
-					Key:      "uint to int",
-					Type:     commonpb.AttributeKeyValue_INT,
-					IntValue: 1234,
+					Key: "uint to int",
+					Value: &commonpb.AnyValue{
+						Value: &commonpb.AnyValue_IntValue{
+							IntValue: 1234,
+						},
+					},
 				},
 				{
-					Key:      "int32 to int",
-					Type:     commonpb.AttributeKeyValue_INT,
-					IntValue: 12345,
+					Key: "int32 to int",
+					Value: &commonpb.AnyValue{
+						Value: &commonpb.AnyValue_IntValue{
+							IntValue: 12345,
+						},
+					},
 				},
 				{
-					Key:      "uint32 to int",
-					Type:     commonpb.AttributeKeyValue_INT,
-					IntValue: 123456,
+					Key: "uint32 to int",
+					Value: &commonpb.AnyValue{
+						Value: &commonpb.AnyValue_IntValue{
+							IntValue: 123456,
+						},
+					},
 				},
 				{
-					Key:      "int64 to int64",
-					Type:     commonpb.AttributeKeyValue_INT,
-					IntValue: 1234567,
+					Key: "int64 to int64",
+					Value: &commonpb.AnyValue{
+						Value: &commonpb.AnyValue_IntValue{
+							IntValue: 1234567,
+						},
+					},
 				},
 				{
-					Key:      "uint64 to int64",
-					Type:     commonpb.AttributeKeyValue_INT,
-					IntValue: 12345678,
+					Key: "uint64 to int64",
+					Value: &commonpb.AnyValue{
+						Value: &commonpb.AnyValue_IntValue{
+							IntValue: 12345678,
+						},
+					},
 				},
 				{
-					Key:         "float32 to double",
-					Type:        commonpb.AttributeKeyValue_DOUBLE,
-					DoubleValue: 3.14,
+					Key: "float32 to double",
+					Value: &commonpb.AnyValue{
+						Value: &commonpb.AnyValue_DoubleValue{
+							DoubleValue: 3.14,
+						},
+					},
 				},
 				{
-					Key:         "float64 to double",
-					Type:        commonpb.AttributeKeyValue_DOUBLE,
-					DoubleValue: 1.61,
+					Key: "float64 to double",
+					Value: &commonpb.AnyValue{
+						Value: &commonpb.AnyValue_DoubleValue{
+							DoubleValue: 1.61,
+						},
+					},
 				},
 				{
-					Key:         "string to string",
-					Type:        commonpb.AttributeKeyValue_STRING,
-					StringValue: "string",
+					Key: "string to string",
+					Value: &commonpb.AnyValue{
+						Value: &commonpb.AnyValue_StringValue{
+							StringValue: "string",
+						},
+					},
 				},
 				{
-					Key:       "bool to bool",
-					Type:      commonpb.AttributeKeyValue_BOOL,
-					BoolValue: true,
+					Key: "bool to bool",
+					Value: &commonpb.AnyValue{
+						Value: &commonpb.AnyValue_BoolValue{
+							BoolValue: true,
+						},
+					},
 				},
 			},
 		},
@@ -101,11 +131,16 @@ func TestAttributes(t *testing.T) {
 			continue
 		}
 		for i, actual := range got {
-			if actual.Type == commonpb.AttributeKeyValue_DOUBLE {
-				if !assert.InDelta(t, test.expected[i].DoubleValue, actual.DoubleValue, 0.01) {
+			if a, ok := actual.Value.Value.(*commonpb.AnyValue_DoubleValue); ok {
+				e, ok := test.expected[i].Value.Value.(*commonpb.AnyValue_DoubleValue)
+				if !ok {
+					t.Errorf("expected AnyValue_DoubleValue, got %T", test.expected[i].Value.Value)
 					continue
 				}
-				test.expected[i].DoubleValue = actual.DoubleValue
+				if !assert.InDelta(t, e.DoubleValue, a.DoubleValue, 0.01) {
+					continue
+				}
+				e.DoubleValue = a.DoubleValue
 			}
 			assert.Equal(t, test.expected[i], actual)
 		}

--- a/internal/transform/instrumentation.go
+++ b/internal/transform/instrumentation.go
@@ -1,0 +1,31 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transform
+
+import (
+	commonpb "github.com/open-telemetry/opentelemetry-proto/gen/go/common/v1"
+
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+)
+
+func instrumentationLibrary(il instrumentation.Library) *commonpb.InstrumentationLibrary {
+	if il == (instrumentation.Library{}) {
+		return nil
+	}
+	return &commonpb.InstrumentationLibrary{
+		Name:    il.Name,
+		Version: il.Version,
+	}
+}

--- a/internal/transform/metric.go
+++ b/internal/transform/metric.go
@@ -1,0 +1,364 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package transform provides translations for opentelemetry-go concepts and
+// structures to otlp structures.
+package transform
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	commonpb "github.com/open-telemetry/opentelemetry-proto/gen/go/common/v1"
+	metricpb "github.com/open-telemetry/opentelemetry-proto/gen/go/metrics/v1"
+	resourcepb "github.com/open-telemetry/opentelemetry-proto/gen/go/resource/v1"
+
+	"go.opentelemetry.io/otel/api/label"
+	"go.opentelemetry.io/otel/api/metric"
+	export "go.opentelemetry.io/otel/sdk/export/metric"
+	"go.opentelemetry.io/otel/sdk/export/metric/aggregation"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+var (
+	// ErrUnimplementedAgg is returned when a transformation of an unimplemented
+	// aggregator is attempted.
+	ErrUnimplementedAgg = errors.New("unimplemented aggregator")
+
+	// ErrUnknownValueType is returned when a transformation of an unknown value
+	// is attempted.
+	ErrUnknownValueType = errors.New("invalid value type")
+
+	// ErrContextCanceled is returned when a context cancellation halts a
+	// transformation.
+	ErrContextCanceled = errors.New("context canceled")
+
+	// ErrTransforming is returned when an unexected error is encoutered transforming.
+	ErrTransforming = errors.New("transforming failed")
+)
+
+// result is the product of transforming Records into OTLP Metrics.
+type result struct {
+	Resource               *resource.Resource
+	InstrumentationLibrary instrumentation.Library
+	Metric                 *metricpb.Metric
+	Err                    error
+}
+
+// CheckpointSet transforms all records contained in a checkpoint into
+// batched OTLP ResourceMetrics.
+func CheckpointSet(ctx context.Context, exportSelector export.ExportKindSelector, cps export.CheckpointSet, numWorkers uint) ([]*metricpb.ResourceMetrics, error) {
+	records, errc := source(ctx, exportSelector, cps)
+
+	// Start a fixed number of goroutines to transform records.
+	transformed := make(chan result)
+	var wg sync.WaitGroup
+	wg.Add(int(numWorkers))
+	for i := uint(0); i < numWorkers; i++ {
+		go func() {
+			defer wg.Done()
+			transformer(ctx, records, transformed)
+		}()
+	}
+	go func() {
+		wg.Wait()
+		close(transformed)
+	}()
+
+	// Synchronously collect the transformed records and transmit.
+	rms, err := sink(ctx, transformed)
+	if err != nil {
+		return nil, err
+	}
+
+	// source is complete, check for any errors.
+	if err := <-errc; err != nil {
+		return nil, err
+	}
+	return rms, nil
+}
+
+// source starts a goroutine that sends each one of the Records yielded by
+// the CheckpointSet on the returned chan. Any error encoutered will be sent
+// on the returned error chan after seeding is complete.
+func source(ctx context.Context, exportSelector export.ExportKindSelector, cps export.CheckpointSet) (<-chan export.Record, <-chan error) {
+	errc := make(chan error, 1)
+	out := make(chan export.Record)
+	// Seed records into process.
+	go func() {
+		defer close(out)
+		// No select is needed since errc is buffered.
+		errc <- cps.ForEach(exportSelector, func(r export.Record) error {
+			select {
+			case <-ctx.Done():
+				return ErrContextCanceled
+			case out <- r:
+			}
+			return nil
+		})
+	}()
+	return out, errc
+}
+
+// transformer transforms records read from the passed in chan into
+// OTLP Metrics which are sent on the out chan.
+func transformer(ctx context.Context, in <-chan export.Record, out chan<- result) {
+	for r := range in {
+		m, err := Record(r)
+		// Propagate errors, but do not send empty results.
+		if err == nil && m == nil {
+			continue
+		}
+		res := result{
+			Resource: r.Resource(),
+			InstrumentationLibrary: instrumentation.Library{
+				Name:    r.Descriptor().InstrumentationName(),
+				Version: r.Descriptor().InstrumentationVersion(),
+			},
+			Metric: m,
+			Err:    err,
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case out <- res:
+		}
+	}
+}
+
+// sink collects transformed Records and batches them.
+//
+// Any errors encoutered transforming input will be reported with an
+// ErrTransforming as well as the completed ResourceMetrics. It is up to the
+// caller to handle any incorrect data in these ResourceMetrics.
+func sink(ctx context.Context, in <-chan result) ([]*metricpb.ResourceMetrics, error) {
+	var errStrings []string
+
+	type resourceBatch struct {
+		Resource *resourcepb.Resource
+		// Group by instrumentation library name and then the MetricDescriptor.
+		InstrumentationLibraryBatches map[instrumentation.Library]map[string]*metricpb.Metric
+	}
+
+	// group by unique Resource string.
+	grouped := make(map[label.Distinct]resourceBatch)
+	for res := range in {
+		if res.Err != nil {
+			errStrings = append(errStrings, res.Err.Error())
+			continue
+		}
+
+		rID := res.Resource.Equivalent()
+		rb, ok := grouped[rID]
+		if !ok {
+			rb = resourceBatch{
+				Resource:                      Resource(res.Resource),
+				InstrumentationLibraryBatches: make(map[instrumentation.Library]map[string]*metricpb.Metric),
+			}
+			grouped[rID] = rb
+		}
+
+		mb, ok := rb.InstrumentationLibraryBatches[res.InstrumentationLibrary]
+		if !ok {
+			mb = make(map[string]*metricpb.Metric)
+			rb.InstrumentationLibraryBatches[res.InstrumentationLibrary] = mb
+		}
+
+		mID := res.Metric.GetMetricDescriptor().String()
+		m, ok := mb[mID]
+		if !ok {
+			mb[mID] = res.Metric
+			continue
+		}
+		if len(res.Metric.Int64DataPoints) > 0 {
+			m.Int64DataPoints = append(m.Int64DataPoints, res.Metric.Int64DataPoints...)
+		}
+		if len(res.Metric.DoubleDataPoints) > 0 {
+			m.DoubleDataPoints = append(m.DoubleDataPoints, res.Metric.DoubleDataPoints...)
+		}
+		if len(res.Metric.HistogramDataPoints) > 0 {
+			m.HistogramDataPoints = append(m.HistogramDataPoints, res.Metric.HistogramDataPoints...)
+		}
+		if len(res.Metric.SummaryDataPoints) > 0 {
+			m.SummaryDataPoints = append(m.SummaryDataPoints, res.Metric.SummaryDataPoints...)
+		}
+	}
+
+	if len(grouped) == 0 {
+		return nil, nil
+	}
+
+	var rms []*metricpb.ResourceMetrics
+	for _, rb := range grouped {
+		rm := &metricpb.ResourceMetrics{Resource: rb.Resource}
+		for il, mb := range rb.InstrumentationLibraryBatches {
+			ilm := &metricpb.InstrumentationLibraryMetrics{
+				Metrics: make([]*metricpb.Metric, 0, len(mb)),
+			}
+			if il != (instrumentation.Library{}) {
+				ilm.InstrumentationLibrary = &commonpb.InstrumentationLibrary{
+					Name:    il.Name,
+					Version: il.Version,
+				}
+			}
+			for _, m := range mb {
+				ilm.Metrics = append(ilm.Metrics, m)
+			}
+			rm.InstrumentationLibraryMetrics = append(rm.InstrumentationLibraryMetrics, ilm)
+		}
+		rms = append(rms, rm)
+	}
+
+	// Report any transform errors.
+	if len(errStrings) > 0 {
+		return rms, fmt.Errorf("%w:\n -%s", ErrTransforming, strings.Join(errStrings, "\n -"))
+	}
+	return rms, nil
+}
+
+// Record transforms a Record into an OTLP Metric. An ErrUnimplementedAgg
+// error is returned if the Record Aggregator is not supported.
+func Record(r export.Record) (*metricpb.Metric, error) {
+	switch a := r.Aggregation().(type) {
+	case aggregation.MinMaxSumCount:
+		return minMaxSumCount(r, a)
+	case aggregation.Sum:
+		return sum(r, a)
+	default:
+		return nil, fmt.Errorf("%w: %v", ErrUnimplementedAgg, a)
+	}
+}
+
+// sum transforms a Sum Aggregator into an OTLP Metric.
+func sum(record export.Record, a aggregation.Sum) (*metricpb.Metric, error) {
+	desc := record.Descriptor()
+	labels := record.Labels()
+	sum, err := a.Sum()
+	if err != nil {
+		return nil, err
+	}
+
+	m := &metricpb.Metric{
+		MetricDescriptor: &metricpb.MetricDescriptor{
+			Name:        desc.Name(),
+			Description: desc.Description(),
+			Unit:        string(desc.Unit()),
+		},
+	}
+
+	switch n := desc.NumberKind(); n {
+	case metric.Int64NumberKind:
+		m.MetricDescriptor.Type = metricpb.MetricDescriptor_INT64
+		m.Int64DataPoints = []*metricpb.Int64DataPoint{
+			{
+				Value:             sum.CoerceToInt64(n),
+				Labels:            stringKeyValues(labels.Iter()),
+				StartTimeUnixNano: uint64(record.StartTime().UnixNano()),
+				TimeUnixNano:      uint64(record.EndTime().UnixNano()),
+			},
+		}
+	case metric.Float64NumberKind:
+		m.MetricDescriptor.Type = metricpb.MetricDescriptor_DOUBLE
+		m.DoubleDataPoints = []*metricpb.DoubleDataPoint{
+			{
+				Value:             sum.CoerceToFloat64(n),
+				Labels:            stringKeyValues(labels.Iter()),
+				StartTimeUnixNano: uint64(record.StartTime().UnixNano()),
+				TimeUnixNano:      uint64(record.EndTime().UnixNano()),
+			},
+		}
+	default:
+		return nil, fmt.Errorf("%w: %v", ErrUnknownValueType, n)
+	}
+
+	return m, nil
+}
+
+// minMaxSumCountValue returns the values of the MinMaxSumCount Aggregator
+// as discret values.
+func minMaxSumCountValues(a aggregation.MinMaxSumCount) (min, max, sum metric.Number, count int64, err error) {
+	if min, err = a.Min(); err != nil {
+		return
+	}
+	if max, err = a.Max(); err != nil {
+		return
+	}
+	if sum, err = a.Sum(); err != nil {
+		return
+	}
+	if count, err = a.Count(); err != nil {
+		return
+	}
+	return
+}
+
+// minMaxSumCount transforms a MinMaxSumCount Aggregator into an OTLP Metric.
+func minMaxSumCount(record export.Record, a aggregation.MinMaxSumCount) (*metricpb.Metric, error) {
+	desc := record.Descriptor()
+	labels := record.Labels()
+	min, max, sum, count, err := minMaxSumCountValues(a)
+	if err != nil {
+		return nil, err
+	}
+
+	numKind := desc.NumberKind()
+	return &metricpb.Metric{
+		MetricDescriptor: &metricpb.MetricDescriptor{
+			Name:        desc.Name(),
+			Description: desc.Description(),
+			Unit:        string(desc.Unit()),
+			Type:        metricpb.MetricDescriptor_SUMMARY,
+		},
+		SummaryDataPoints: []*metricpb.SummaryDataPoint{
+			{
+				Labels: stringKeyValues(labels.Iter()),
+				Count:  uint64(count),
+				Sum:    sum.CoerceToFloat64(numKind),
+				PercentileValues: []*metricpb.SummaryDataPoint_ValueAtPercentile{
+					{
+						Percentile: 0.0,
+						Value:      min.CoerceToFloat64(numKind),
+					},
+					{
+						Percentile: 100.0,
+						Value:      max.CoerceToFloat64(numKind),
+					},
+				},
+				StartTimeUnixNano: uint64(record.StartTime().UnixNano()),
+				TimeUnixNano:      uint64(record.EndTime().UnixNano()),
+			},
+		},
+	}, nil
+}
+
+// stringKeyValues transforms a label iterator into an OTLP StringKeyValues.
+func stringKeyValues(iter label.Iterator) []*commonpb.StringKeyValue {
+	l := iter.Len()
+	if l == 0 {
+		return nil
+	}
+	result := make([]*commonpb.StringKeyValue, 0, l)
+	for iter.Next() {
+		kv := iter.Label()
+		result = append(result, &commonpb.StringKeyValue{
+			Key:   string(kv.Key),
+			Value: kv.Value.Emit(),
+		})
+	}
+	return result
+}

--- a/internal/transform/metric_test.go
+++ b/internal/transform/metric_test.go
@@ -1,0 +1,322 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transform
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	commonpb "github.com/open-telemetry/opentelemetry-proto/gen/go/common/v1"
+	metricpb "github.com/open-telemetry/opentelemetry-proto/gen/go/metrics/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/otel/api/kv"
+	"go.opentelemetry.io/otel/api/label"
+	"go.opentelemetry.io/otel/api/metric"
+	"go.opentelemetry.io/otel/api/unit"
+	"go.opentelemetry.io/otel/exporters/metric/test"
+	export "go.opentelemetry.io/otel/sdk/export/metric"
+	"go.opentelemetry.io/otel/sdk/export/metric/aggregation"
+	"go.opentelemetry.io/otel/sdk/metric/aggregator/minmaxsumcount"
+	sumAgg "go.opentelemetry.io/otel/sdk/metric/aggregator/sum"
+)
+
+var (
+	// Timestamps used in this test:
+
+	intervalStart = time.Now()
+	intervalEnd   = intervalStart.Add(time.Hour)
+)
+
+func TestStringKeyValues(t *testing.T) {
+	tests := []struct {
+		kvs      []kv.KeyValue
+		expected []*commonpb.StringKeyValue
+	}{
+		{
+			nil,
+			nil,
+		},
+		{
+			[]kv.KeyValue{},
+			nil,
+		},
+		{
+			[]kv.KeyValue{
+				kv.Bool("true", true),
+				kv.Int64("one", 1),
+				kv.Uint64("two", 2),
+				kv.Float64("three", 3),
+				kv.Int32("four", 4),
+				kv.Uint32("five", 5),
+				kv.Float32("six", 6),
+				kv.Int("seven", 7),
+				kv.Uint("eight", 8),
+				kv.String("the", "final word"),
+			},
+			[]*commonpb.StringKeyValue{
+				{Key: "eight", Value: "8"},
+				{Key: "five", Value: "5"},
+				{Key: "four", Value: "4"},
+				{Key: "one", Value: "1"},
+				{Key: "seven", Value: "7"},
+				{Key: "six", Value: "6"},
+				{Key: "the", Value: "final word"},
+				{Key: "three", Value: "3"},
+				{Key: "true", Value: "true"},
+				{Key: "two", Value: "2"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		labels := label.NewSet(test.kvs...)
+		assert.Equal(t, test.expected, stringKeyValues(labels.Iter()))
+	}
+}
+
+func TestMinMaxSumCountValue(t *testing.T) {
+	mmsc, ckpt := test.Unslice2(minmaxsumcount.New(2, &metric.Descriptor{}))
+
+	assert.NoError(t, mmsc.Update(context.Background(), 1, &metric.Descriptor{}))
+	assert.NoError(t, mmsc.Update(context.Background(), 10, &metric.Descriptor{}))
+
+	// Prior to checkpointing ErrNoData should be returned.
+	_, _, _, _, err := minMaxSumCountValues(ckpt.(aggregation.MinMaxSumCount))
+	assert.EqualError(t, err, aggregation.ErrNoData.Error())
+
+	// Checkpoint to set non-zero values
+	require.NoError(t, mmsc.SynchronizedMove(ckpt, &metric.Descriptor{}))
+	min, max, sum, count, err := minMaxSumCountValues(ckpt.(aggregation.MinMaxSumCount))
+	if assert.NoError(t, err) {
+		assert.Equal(t, min, metric.NewInt64Number(1))
+		assert.Equal(t, max, metric.NewInt64Number(10))
+		assert.Equal(t, sum, metric.NewInt64Number(11))
+		assert.Equal(t, count, int64(2))
+	}
+}
+
+func TestMinMaxSumCountMetricDescriptor(t *testing.T) {
+	tests := []struct {
+		name        string
+		metricKind  metric.Kind
+		description string
+		unit        unit.Unit
+		numberKind  metric.NumberKind
+		labels      []kv.KeyValue
+		expected    *metricpb.MetricDescriptor
+	}{
+		{
+			"mmsc-test-a",
+			metric.ValueRecorderKind,
+			"test-a-description",
+			unit.Dimensionless,
+			metric.Int64NumberKind,
+			[]kv.KeyValue{},
+			&metricpb.MetricDescriptor{
+				Name:        "mmsc-test-a",
+				Description: "test-a-description",
+				Unit:        "1",
+				Type:        metricpb.MetricDescriptor_SUMMARY,
+			},
+		},
+		{
+			"mmsc-test-b",
+			metric.CounterKind, // This shouldn't change anything.
+			"test-b-description",
+			unit.Bytes,
+			metric.Float64NumberKind, // This shouldn't change anything.
+			[]kv.KeyValue{kv.String("A", "1")},
+			&metricpb.MetricDescriptor{
+				Name:        "mmsc-test-b",
+				Description: "test-b-description",
+				Unit:        "By",
+				Type:        metricpb.MetricDescriptor_SUMMARY,
+			},
+		},
+	}
+
+	ctx := context.Background()
+	mmsc, ckpt := test.Unslice2(minmaxsumcount.New(2, &metric.Descriptor{}))
+	if !assert.NoError(t, mmsc.Update(ctx, 1, &metric.Descriptor{})) {
+		return
+	}
+	require.NoError(t, mmsc.SynchronizedMove(ckpt, &metric.Descriptor{}))
+	for _, test := range tests {
+		desc := metric.NewDescriptor(test.name, test.metricKind, test.numberKind,
+			metric.WithDescription(test.description),
+			metric.WithUnit(test.unit))
+		labels := label.NewSet(test.labels...)
+		record := export.NewRecord(&desc, &labels, nil, ckpt.Aggregation(), intervalStart, intervalEnd)
+		got, err := minMaxSumCount(record, ckpt.(aggregation.MinMaxSumCount))
+		if assert.NoError(t, err) {
+			assert.Equal(t, test.expected, got.MetricDescriptor)
+		}
+	}
+}
+
+func TestMinMaxSumCountDatapoints(t *testing.T) {
+	desc := metric.NewDescriptor("", metric.ValueRecorderKind, metric.Int64NumberKind)
+	labels := label.NewSet()
+	mmsc, ckpt := test.Unslice2(minmaxsumcount.New(2, &desc))
+
+	assert.NoError(t, mmsc.Update(context.Background(), 1, &desc))
+	assert.NoError(t, mmsc.Update(context.Background(), 10, &desc))
+	require.NoError(t, mmsc.SynchronizedMove(ckpt, &desc))
+	expected := []*metricpb.SummaryDataPoint{
+		{
+			Count: 2,
+			Sum:   11,
+			PercentileValues: []*metricpb.SummaryDataPoint_ValueAtPercentile{
+				{
+					Percentile: 0.0,
+					Value:      1,
+				},
+				{
+					Percentile: 100.0,
+					Value:      10,
+				},
+			},
+			StartTimeUnixNano: uint64(intervalStart.UnixNano()),
+			TimeUnixNano:      uint64(intervalEnd.UnixNano()),
+		},
+	}
+	record := export.NewRecord(&desc, &labels, nil, ckpt.Aggregation(), intervalStart, intervalEnd)
+	m, err := minMaxSumCount(record, ckpt.(aggregation.MinMaxSumCount))
+	if assert.NoError(t, err) {
+		assert.Equal(t, []*metricpb.Int64DataPoint(nil), m.Int64DataPoints)
+		assert.Equal(t, []*metricpb.DoubleDataPoint(nil), m.DoubleDataPoints)
+		assert.Equal(t, []*metricpb.HistogramDataPoint(nil), m.HistogramDataPoints)
+		assert.Equal(t, expected, m.SummaryDataPoints)
+	}
+}
+
+func TestMinMaxSumCountPropagatesErrors(t *testing.T) {
+	// ErrNoData should be returned by both the Min and Max values of
+	// a MinMaxSumCount Aggregator. Use this fact to check the error is
+	// correctly returned.
+	mmsc := &minmaxsumcount.New(1, &metric.Descriptor{})[0]
+	_, _, _, _, err := minMaxSumCountValues(mmsc)
+	assert.Error(t, err)
+	assert.Equal(t, aggregation.ErrNoData, err)
+}
+
+func TestSumMetricDescriptor(t *testing.T) {
+	tests := []struct {
+		name        string
+		metricKind  metric.Kind
+		description string
+		unit        unit.Unit
+		numberKind  metric.NumberKind
+		labels      []kv.KeyValue
+		expected    *metricpb.MetricDescriptor
+	}{
+		{
+			"sum-test-a",
+			metric.CounterKind,
+			"test-a-description",
+			unit.Dimensionless,
+			metric.Int64NumberKind,
+			[]kv.KeyValue{},
+			&metricpb.MetricDescriptor{
+				Name:        "sum-test-a",
+				Description: "test-a-description",
+				Unit:        "1",
+				Type:        metricpb.MetricDescriptor_INT64,
+			},
+		},
+		{
+			"sum-test-b",
+			metric.ValueRecorderKind, // This shouldn't change anything.
+			"test-b-description",
+			unit.Milliseconds,
+			metric.Float64NumberKind,
+			[]kv.KeyValue{kv.String("A", "1")},
+			&metricpb.MetricDescriptor{
+				Name:        "sum-test-b",
+				Description: "test-b-description",
+				Unit:        "ms",
+				Type:        metricpb.MetricDescriptor_DOUBLE,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		desc := metric.NewDescriptor(test.name, test.metricKind, test.numberKind,
+			metric.WithDescription(test.description),
+			metric.WithUnit(test.unit),
+		)
+		labels := label.NewSet(test.labels...)
+		emptyAgg := &sumAgg.New(1)[0]
+		record := export.NewRecord(&desc, &labels, nil, emptyAgg, intervalStart, intervalEnd)
+		got, err := sum(record, emptyAgg)
+		if assert.NoError(t, err) {
+			assert.Equal(t, test.expected, got.MetricDescriptor)
+		}
+	}
+}
+
+func TestSumInt64DataPoints(t *testing.T) {
+	desc := metric.NewDescriptor("", metric.ValueRecorderKind, metric.Int64NumberKind)
+	labels := label.NewSet()
+	s, ckpt := test.Unslice2(sumAgg.New(2))
+	assert.NoError(t, s.Update(context.Background(), metric.Number(1), &desc))
+	require.NoError(t, s.SynchronizedMove(ckpt, &desc))
+	record := export.NewRecord(&desc, &labels, nil, ckpt.Aggregation(), intervalStart, intervalEnd)
+	if m, err := sum(record, ckpt.(aggregation.Sum)); assert.NoError(t, err) {
+		assert.Equal(t, []*metricpb.Int64DataPoint{{
+			Value:             1,
+			StartTimeUnixNano: uint64(intervalStart.UnixNano()),
+			TimeUnixNano:      uint64(intervalEnd.UnixNano()),
+		}}, m.Int64DataPoints)
+		assert.Equal(t, []*metricpb.DoubleDataPoint(nil), m.DoubleDataPoints)
+		assert.Equal(t, []*metricpb.HistogramDataPoint(nil), m.HistogramDataPoints)
+		assert.Equal(t, []*metricpb.SummaryDataPoint(nil), m.SummaryDataPoints)
+	}
+}
+
+func TestSumFloat64DataPoints(t *testing.T) {
+	desc := metric.NewDescriptor("", metric.ValueRecorderKind, metric.Float64NumberKind)
+	labels := label.NewSet()
+	s, ckpt := test.Unslice2(sumAgg.New(2))
+	assert.NoError(t, s.Update(context.Background(), metric.NewFloat64Number(1), &desc))
+	require.NoError(t, s.SynchronizedMove(ckpt, &desc))
+	record := export.NewRecord(&desc, &labels, nil, ckpt.Aggregation(), intervalStart, intervalEnd)
+	if m, err := sum(record, ckpt.(aggregation.Sum)); assert.NoError(t, err) {
+		assert.Equal(t, []*metricpb.Int64DataPoint(nil), m.Int64DataPoints)
+		assert.Equal(t, []*metricpb.DoubleDataPoint{{
+			Value:             1,
+			StartTimeUnixNano: uint64(intervalStart.UnixNano()),
+			TimeUnixNano:      uint64(intervalEnd.UnixNano()),
+		}}, m.DoubleDataPoints)
+		assert.Equal(t, []*metricpb.HistogramDataPoint(nil), m.HistogramDataPoints)
+		assert.Equal(t, []*metricpb.SummaryDataPoint(nil), m.SummaryDataPoints)
+	}
+}
+
+func TestSumErrUnknownValueType(t *testing.T) {
+	desc := metric.NewDescriptor("", metric.ValueRecorderKind, metric.NumberKind(-1))
+	labels := label.NewSet()
+	s := &sumAgg.New(1)[0]
+	record := export.NewRecord(&desc, &labels, nil, s, intervalStart, intervalEnd)
+	_, err := sum(record, s)
+	assert.Error(t, err)
+	if !errors.Is(err, ErrUnknownValueType) {
+		t.Errorf("expected ErrUnknownValueType, got %v", err)
+	}
+}

--- a/internal/transform/span.go
+++ b/internal/transform/span.go
@@ -1,0 +1,205 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transform
+
+import (
+	"google.golang.org/grpc/codes"
+
+	tracepb "github.com/open-telemetry/opentelemetry-proto/gen/go/trace/v1"
+
+	"go.opentelemetry.io/otel/api/label"
+	apitrace "go.opentelemetry.io/otel/api/trace"
+	export "go.opentelemetry.io/otel/sdk/export/trace"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+)
+
+const (
+	maxMessageEventsPerSpan = 128
+)
+
+// SpanData transforms a slice of SpanData into a slice of OTLP ResourceSpans.
+func SpanData(sdl []*export.SpanData) []*tracepb.ResourceSpans {
+	if len(sdl) == 0 {
+		return nil
+	}
+
+	rsm := make(map[label.Distinct]*tracepb.ResourceSpans)
+
+	type ilsKey struct {
+		r  label.Distinct
+		il instrumentation.Library
+	}
+	ilsm := make(map[ilsKey]*tracepb.InstrumentationLibrarySpans)
+
+	var resources int
+	for _, sd := range sdl {
+		if sd == nil {
+			continue
+		}
+
+		rKey := sd.Resource.Equivalent()
+		iKey := ilsKey{
+			r:  rKey,
+			il: sd.InstrumentationLibrary,
+		}
+		ils, iOk := ilsm[iKey]
+		if !iOk {
+			// Either the resource or instrumentation library were unknown.
+			ils = &tracepb.InstrumentationLibrarySpans{
+				InstrumentationLibrary: instrumentationLibrary(sd.InstrumentationLibrary),
+				Spans:                  []*tracepb.Span{},
+			}
+		}
+		ils.Spans = append(ils.Spans, span(sd))
+		ilsm[iKey] = ils
+
+		rs, rOk := rsm[rKey]
+		if !rOk {
+			resources++
+			// The resource was unknown.
+			rs = &tracepb.ResourceSpans{
+				Resource:                    Resource(sd.Resource),
+				InstrumentationLibrarySpans: []*tracepb.InstrumentationLibrarySpans{ils},
+			}
+			rsm[rKey] = rs
+			continue
+		}
+
+		// The resource has been seen before. Check if the instrumentation
+		// library lookup was unknown because if so we need to add it to the
+		// ResourceSpans. Otherwise, the instrumentation library has already
+		// been seen and the append we did above will be included it in the
+		// InstrumentationLibrarySpans reference.
+		if !iOk {
+			rs.InstrumentationLibrarySpans = append(rs.InstrumentationLibrarySpans, ils)
+		}
+	}
+
+	// Transform the categorized map into a slice
+	rss := make([]*tracepb.ResourceSpans, 0, resources)
+	for _, rs := range rsm {
+		rss = append(rss, rs)
+	}
+	return rss
+}
+
+// span transforms a Span into an OTLP span.
+func span(sd *export.SpanData) *tracepb.Span {
+	if sd == nil {
+		return nil
+	}
+
+	s := &tracepb.Span{
+		TraceId:           sd.SpanContext.TraceID[:],
+		SpanId:            sd.SpanContext.SpanID[:],
+		Status:            status(sd.StatusCode, sd.StatusMessage),
+		StartTimeUnixNano: uint64(sd.StartTime.UnixNano()),
+		EndTimeUnixNano:   uint64(sd.EndTime.UnixNano()),
+		Links:             links(sd.Links),
+		Kind:              spanKind(sd.SpanKind),
+		Name:              sd.Name,
+		Attributes:        Attributes(sd.Attributes),
+		Events:            spanEvents(sd.MessageEvents),
+		// TODO (rghetia): Add Tracestate: when supported.
+		DroppedAttributesCount: uint32(sd.DroppedAttributeCount),
+		DroppedEventsCount:     uint32(sd.DroppedMessageEventCount),
+		DroppedLinksCount:      uint32(sd.DroppedLinkCount),
+	}
+
+	if sd.ParentSpanID.IsValid() {
+		s.ParentSpanId = sd.ParentSpanID[:]
+	}
+
+	return s
+}
+
+// status transform a span code and message into an OTLP span status.
+func status(status codes.Code, message string) *tracepb.Status {
+	return &tracepb.Status{
+		Code:    tracepb.Status_StatusCode(status),
+		Message: message,
+	}
+}
+
+// links transforms span Links to OTLP span links.
+func links(links []apitrace.Link) []*tracepb.Span_Link {
+	if len(links) == 0 {
+		return nil
+	}
+
+	sl := make([]*tracepb.Span_Link, 0, len(links))
+	for _, otLink := range links {
+		// This redefinition is necessary to prevent otLink.*ID[:] copies
+		// being reused -- in short we need a new otLink per iteration.
+		otLink := otLink
+
+		sl = append(sl, &tracepb.Span_Link{
+			TraceId:    otLink.TraceID[:],
+			SpanId:     otLink.SpanID[:],
+			Attributes: Attributes(otLink.Attributes),
+		})
+	}
+	return sl
+}
+
+// spanEvents transforms span Events to an OTLP span events.
+func spanEvents(es []export.Event) []*tracepb.Span_Event {
+	if len(es) == 0 {
+		return nil
+	}
+
+	evCount := len(es)
+	if evCount > maxMessageEventsPerSpan {
+		evCount = maxMessageEventsPerSpan
+	}
+	events := make([]*tracepb.Span_Event, 0, evCount)
+	messageEvents := 0
+
+	// Transform message events
+	for _, e := range es {
+		if messageEvents >= maxMessageEventsPerSpan {
+			break
+		}
+		messageEvents++
+		events = append(events,
+			&tracepb.Span_Event{
+				Name:         e.Name,
+				TimeUnixNano: uint64(e.Time.Nanosecond()),
+				Attributes:   Attributes(e.Attributes),
+				// TODO (rghetia) : Add Drop Counts when supported.
+			},
+		)
+	}
+
+	return events
+}
+
+// spanKind transforms a SpanKind to an OTLP span kind.
+func spanKind(kind apitrace.SpanKind) tracepb.Span_SpanKind {
+	switch kind {
+	case apitrace.SpanKindInternal:
+		return tracepb.Span_INTERNAL
+	case apitrace.SpanKindClient:
+		return tracepb.Span_CLIENT
+	case apitrace.SpanKindServer:
+		return tracepb.Span_SERVER
+	case apitrace.SpanKindProducer:
+		return tracepb.Span_PRODUCER
+	case apitrace.SpanKindConsumer:
+		return tracepb.Span_CONSUMER
+	default:
+		return tracepb.Span_SPAN_KIND_UNSPECIFIED
+	}
+}

--- a/internal/transform/span_test.go
+++ b/internal/transform/span_test.go
@@ -1,0 +1,381 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package transform
+
+import (
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
+	tracepb "github.com/open-telemetry/opentelemetry-proto/gen/go/trace/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+
+	"go.opentelemetry.io/otel/api/kv"
+	apitrace "go.opentelemetry.io/otel/api/trace"
+	export "go.opentelemetry.io/otel/sdk/export/trace"
+	"go.opentelemetry.io/otel/sdk/instrumentation"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+func TestSpanKind(t *testing.T) {
+	for _, test := range []struct {
+		kind     apitrace.SpanKind
+		expected tracepb.Span_SpanKind
+	}{
+		{
+			apitrace.SpanKindInternal,
+			tracepb.Span_INTERNAL,
+		},
+		{
+			apitrace.SpanKindClient,
+			tracepb.Span_CLIENT,
+		},
+		{
+			apitrace.SpanKindServer,
+			tracepb.Span_SERVER,
+		},
+		{
+			apitrace.SpanKindProducer,
+			tracepb.Span_PRODUCER,
+		},
+		{
+			apitrace.SpanKindConsumer,
+			tracepb.Span_CONSUMER,
+		},
+		{
+			apitrace.SpanKind(-1),
+			tracepb.Span_SPAN_KIND_UNSPECIFIED,
+		},
+	} {
+		assert.Equal(t, test.expected, spanKind(test.kind))
+	}
+}
+
+func TestNilSpanEvent(t *testing.T) {
+	assert.Nil(t, spanEvents(nil))
+}
+
+func TestEmptySpanEvent(t *testing.T) {
+	assert.Nil(t, spanEvents([]export.Event{}))
+}
+
+func TestSpanEvent(t *testing.T) {
+	attrs := []kv.KeyValue{kv.Int("one", 1), kv.Int("two", 2)}
+	now := time.Now()
+	got := spanEvents([]export.Event{
+		{
+			Name:       "test 1",
+			Attributes: []kv.KeyValue{},
+			Time:       now,
+		},
+		{
+			Name:       "test 2",
+			Attributes: attrs,
+			Time:       now,
+		},
+	})
+	if !assert.Len(t, got, 2) {
+		return
+	}
+	uNow := uint64(now.Nanosecond())
+	assert.Equal(t, &tracepb.Span_Event{Name: "test 1", Attributes: nil, TimeUnixNano: uNow}, got[0])
+	// Do not test Attributes directly, just that the return value goes to the correct field.
+	assert.Equal(t, &tracepb.Span_Event{Name: "test 2", Attributes: Attributes(attrs), TimeUnixNano: uNow}, got[1])
+}
+
+func TestExcessiveSpanEvents(t *testing.T) {
+	e := make([]export.Event, maxMessageEventsPerSpan+1)
+	for i := 0; i < maxMessageEventsPerSpan+1; i++ {
+		e[i] = export.Event{Name: strconv.Itoa(i)}
+	}
+	assert.Len(t, e, maxMessageEventsPerSpan+1)
+	got := spanEvents(e)
+	assert.Len(t, got, maxMessageEventsPerSpan)
+	// Ensure the drop order.
+	assert.Equal(t, strconv.Itoa(maxMessageEventsPerSpan-1), got[len(got)-1].Name)
+}
+
+func TestNilLinks(t *testing.T) {
+	assert.Nil(t, links(nil))
+}
+
+func TestEmptyLinks(t *testing.T) {
+	assert.Nil(t, links([]apitrace.Link{}))
+}
+
+func TestLinks(t *testing.T) {
+	attrs := []kv.KeyValue{kv.Int("one", 1), kv.Int("two", 2)}
+	l := []apitrace.Link{
+		{},
+		{
+			SpanContext: apitrace.EmptySpanContext(),
+			Attributes:  attrs,
+		},
+	}
+	got := links(l)
+
+	// Make sure we get the same number back first.
+	if !assert.Len(t, got, 2) {
+		return
+	}
+
+	// Empty should be empty.
+	expected := &tracepb.Span_Link{
+		TraceId: []uint8{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+		SpanId:  []uint8{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
+	}
+	assert.Equal(t, expected, got[0])
+
+	// Do not test Attributes directly, just that the return value goes to the correct field.
+	expected.Attributes = Attributes(attrs)
+	assert.Equal(t, expected, got[1])
+
+	// Changes to our links should not change the produced links.
+	l[1].TraceID[0] = byte(0x1)
+	l[1].SpanID[0] = byte(0x1)
+	assert.Equal(t, expected, got[1])
+}
+
+func TestStatus(t *testing.T) {
+	for _, test := range []struct {
+		grpcCode   codes.Code
+		message    string
+		otlpStatus tracepb.Status_StatusCode
+	}{
+		{
+			codes.OK,
+			"test OK",
+			tracepb.Status_Ok,
+		},
+		{
+			codes.Canceled,
+			//nolint
+			"test CANCELLED",
+			//nolint
+			tracepb.Status_Cancelled,
+		},
+		{
+			codes.Unknown,
+			"test UNKNOWN",
+			tracepb.Status_UnknownError,
+		},
+		{
+			codes.InvalidArgument,
+			"test INVALID_ARGUMENT",
+			tracepb.Status_InvalidArgument,
+		},
+		{
+			codes.DeadlineExceeded,
+			"test DEADLINE_EXCEEDED",
+			tracepb.Status_DeadlineExceeded,
+		},
+		{
+			codes.NotFound,
+			"test NOT_FOUND",
+			tracepb.Status_NotFound,
+		},
+		{
+			codes.AlreadyExists,
+			"test ALREADY_EXISTS",
+			tracepb.Status_AlreadyExists,
+		},
+		{
+			codes.PermissionDenied,
+			"test PERMISSION_DENIED",
+			tracepb.Status_PermissionDenied,
+		},
+		{
+			codes.ResourceExhausted,
+			"test RESOURCE_EXHAUSTED",
+			tracepb.Status_ResourceExhausted,
+		},
+		{
+			codes.FailedPrecondition,
+			"test FAILED_PRECONDITION",
+			tracepb.Status_FailedPrecondition,
+		},
+		{
+			codes.Aborted,
+			"test ABORTED",
+			tracepb.Status_Aborted,
+		},
+		{
+			codes.OutOfRange,
+			"test OUT_OF_RANGE",
+			tracepb.Status_OutOfRange,
+		},
+		{
+			codes.Unimplemented,
+			"test UNIMPLEMENTED",
+			tracepb.Status_Unimplemented,
+		},
+		{
+			codes.Internal,
+			"test INTERNAL",
+			tracepb.Status_InternalError,
+		},
+		{
+			codes.Unavailable,
+			"test UNAVAILABLE",
+			tracepb.Status_Unavailable,
+		},
+		{
+			codes.DataLoss,
+			"test DATA_LOSS",
+			tracepb.Status_DataLoss,
+		},
+		{
+			codes.Unauthenticated,
+			"test UNAUTHENTICATED",
+			tracepb.Status_Unauthenticated,
+		},
+	} {
+		expected := &tracepb.Status{Code: test.otlpStatus, Message: test.message}
+		assert.Equal(t, expected, status(test.grpcCode, test.message))
+	}
+
+}
+
+func TestNilSpan(t *testing.T) {
+	assert.Nil(t, span(nil))
+}
+
+func TestNilSpanData(t *testing.T) {
+	assert.Nil(t, SpanData(nil))
+}
+
+func TestEmptySpanData(t *testing.T) {
+	assert.Nil(t, SpanData(nil))
+}
+
+func TestSpanData(t *testing.T) {
+	// Full test of span data transform.
+
+	// March 31, 2020 5:01:26 1234nanos (UTC)
+	startTime := time.Unix(1585674086, 1234)
+	endTime := startTime.Add(10 * time.Second)
+	spanData := &export.SpanData{
+		SpanContext: apitrace.SpanContext{
+			TraceID: apitrace.ID{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
+			SpanID:  apitrace.SpanID{0xFF, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA, 0xF9, 0xF8},
+		},
+		SpanKind:     apitrace.SpanKindServer,
+		ParentSpanID: apitrace.SpanID{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8},
+		Name:         "span data to span data",
+		StartTime:    startTime,
+		EndTime:      endTime,
+		MessageEvents: []export.Event{
+			{Time: startTime,
+				Attributes: []kv.KeyValue{
+					kv.Uint64("CompressedByteSize", 512),
+				},
+			},
+			{Time: endTime,
+				Attributes: []kv.KeyValue{
+					kv.String("MessageEventType", "Recv"),
+				},
+			},
+		},
+		Links: []apitrace.Link{
+			{
+				SpanContext: apitrace.SpanContext{
+					TraceID:    apitrace.ID{0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7, 0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF},
+					SpanID:     apitrace.SpanID{0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7},
+					TraceFlags: 0,
+				},
+				Attributes: []kv.KeyValue{
+					kv.String("LinkType", "Parent"),
+				},
+			},
+			{
+				SpanContext: apitrace.SpanContext{
+					TraceID:    apitrace.ID{0xE0, 0xE1, 0xE2, 0xE3, 0xE4, 0xE5, 0xE6, 0xE7, 0xE8, 0xE9, 0xEA, 0xEB, 0xEC, 0xED, 0xEE, 0xEF},
+					SpanID:     apitrace.SpanID{0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7},
+					TraceFlags: 0,
+				},
+				Attributes: []kv.KeyValue{
+					kv.String("LinkType", "Child"),
+				},
+			},
+		},
+		StatusCode:      codes.Internal,
+		StatusMessage:   "utterly unrecognized",
+		HasRemoteParent: true,
+		Attributes: []kv.KeyValue{
+			kv.Int64("timeout_ns", 12e9),
+		},
+		DroppedAttributeCount:    1,
+		DroppedMessageEventCount: 2,
+		DroppedLinkCount:         3,
+		Resource:                 resource.New(kv.String("rk1", "rv1"), kv.Int64("rk2", 5)),
+		InstrumentationLibrary: instrumentation.Library{
+			Name:    "go.opentelemetry.io/test/otel",
+			Version: "v0.0.1",
+		},
+	}
+
+	// Not checking resource as the underlying map of our Resource makes
+	// ordering impossible to guarantee on the output. The Resource
+	// transform function has unit tests that should suffice.
+	expectedSpan := &tracepb.Span{
+		TraceId:                []byte{0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F},
+		SpanId:                 []byte{0xFF, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA, 0xF9, 0xF8},
+		ParentSpanId:           []byte{0xEF, 0xEE, 0xED, 0xEC, 0xEB, 0xEA, 0xE9, 0xE8},
+		Name:                   spanData.Name,
+		Kind:                   tracepb.Span_SERVER,
+		StartTimeUnixNano:      uint64(startTime.UnixNano()),
+		EndTimeUnixNano:        uint64(endTime.UnixNano()),
+		Status:                 status(spanData.StatusCode, spanData.StatusMessage),
+		Events:                 spanEvents(spanData.MessageEvents),
+		Links:                  links(spanData.Links),
+		Attributes:             Attributes(spanData.Attributes),
+		DroppedAttributesCount: 1,
+		DroppedEventsCount:     2,
+		DroppedLinksCount:      3,
+	}
+
+	got := SpanData([]*export.SpanData{spanData})
+	require.Len(t, got, 1)
+
+	assert.Equal(t, got[0].GetResource(), Resource(spanData.Resource))
+	ilSpans := got[0].GetInstrumentationLibrarySpans()
+	require.Len(t, ilSpans, 1)
+	assert.Equal(t, ilSpans[0].GetInstrumentationLibrary(), instrumentationLibrary(spanData.InstrumentationLibrary))
+	require.Len(t, ilSpans[0].Spans, 1)
+	actualSpan := ilSpans[0].Spans[0]
+
+	if diff := cmp.Diff(expectedSpan, actualSpan, cmp.Comparer(proto.Equal)); diff != "" {
+		t.Fatalf("transformed span differs %v\n", diff)
+	}
+}
+
+// Empty parent span ID should be treated as root span.
+func TestRootSpanData(t *testing.T) {
+	sd := SpanData([]*export.SpanData{{}})
+	require.Len(t, sd, 1)
+	rs := sd[0]
+	got := rs.GetInstrumentationLibrarySpans()[0].GetSpans()[0].GetParentSpanId()
+
+	// Empty means root span.
+	assert.Nil(t, got, "incorrect transform of root parent span ID")
+}
+
+func TestSpanDataNilResource(t *testing.T) {
+	assert.NotPanics(t, func() { SpanData([]*export.SpanData{{}}) })
+}


### PR DESCRIPTION
Updates the dependencies to work with the latest versions of the SDK and collector. Also changes the proto dependency from `vmingchen` to `open-telemetry`, using a replace directive to tie it to a local package during developement. A couple changes would be required locally after applying this PR:

* obtain a copy of `vmingchen/opentelemetry-proto` and keep it in the same directory as this repo. Ensure that the proto repo is set to the branch `dynamic-config-service-proto`
* run `go mod init` in the proto repo to generate a dummy `go.mod`. This may be required because the replace directive requires a module, rather than an arbitrary package (for now). Once the proto files are merged upstream and the replace directive is no longer needed, the `go.mod` hack will no longer be needed.